### PR TITLE
Fix Mono detection

### DIFF
--- a/src/Testing/src/TestPlatformHelper.cs
+++ b/src/Testing/src/TestPlatformHelper.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.InternalTesting;
 public static class TestPlatformHelper
 {
     public static bool IsMono =>
-        Type.GetType("Mono.Runtime") != null;
+        Type.GetType("Mono.Runtime") != null || Type.GetType("Mono.RuntimeStructs") != null;
 
     public static bool IsWindows =>
         RuntimeInformation.IsOSPlatform(OSPlatform.Windows);


### PR DESCRIPTION
## Fix Mono detection in TestPlatformHelper

### Summary
Fixes `TestPlatformHelper.IsMono` to detect modern Mono runtime (.NET 6+).

### Problem
`IsMono` only checked for `Mono.Runtime` type, which exists in old Mono but not modern Mono (.NET 6+). This caused tests marked with `[FrameworkSkipCondition(RuntimeFrameworks.Mono)]` to run on Mono when they should have been skipped.


cc: @giritrivedi